### PR TITLE
2.72 に https://groups.google.com/forum/#!topic/mogile/zqe3oA2tHqY のパッチを取り入れる

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,4 +7,4 @@ cd $DIR
 ./cpanm -L extlib --mirror=$(pwd)/cpan-mirror/ --mirror-only --installdeps . "$@"
 
 # http://bogomips.org/MogileFS-Server.git/patch/?id=8b76d98f80b5ab231634f6e0253a2d71c41e02f8
-patch -d extlib/lib/perl5/ -p2 < patch/00-replicate-avoid-buffered-IO-on-reads.patch
+patch -N -d extlib/lib/perl5/ -p2 < patch/00-replicate-avoid-buffered-IO-on-reads.patch

--- a/install.sh
+++ b/install.sh
@@ -6,3 +6,5 @@ DIR=$(dirname $(readlink -f $0))
 cd $DIR
 ./cpanm -L extlib --mirror=$(pwd)/cpan-mirror/ --mirror-only --installdeps . "$@"
 
+# http://bogomips.org/MogileFS-Server.git/patch/?id=8b76d98f80b5ab231634f6e0253a2d71c41e02f8
+patch -d extlib/lib/perl5/ -p2 < patch/00-replicate-avoid-buffered-IO-on-reads.patch

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,10 @@ set -e
 
 DIR=$(dirname $(readlink -f $0))
 cd $DIR
+
+# 既に patch 済みの場合の hunk を避けるバッドハックなのだけど、ベターな回避方法ないかな
+rm -rf extlib/lib/perl5/MogileFS
 ./cpanm -L extlib --mirror=$(pwd)/cpan-mirror/ --mirror-only --installdeps . "$@"
 
 # http://bogomips.org/MogileFS-Server.git/patch/?id=8b76d98f80b5ab231634f6e0253a2d71c41e02f8
-patch -N -d extlib/lib/perl5/ -p2 < patch/00-replicate-avoid-buffered-IO-on-reads.patch
+patch -d extlib/lib/perl5/ -p2 < patch/00-replicate-avoid-buffered-IO-on-reads.patch

--- a/patch/00-replicate-avoid-buffered-IO-on-reads.patch
+++ b/patch/00-replicate-avoid-buffered-IO-on-reads.patch
@@ -1,0 +1,196 @@
+From 8b76d98f80b5ab231634f6e0253a2d71c41e02f8 Mon Sep 17 00:00:00 2001
+From: Eric Wong <e@80x24.org>
+Date: Thu, 17 Dec 2015 03:57:38 +0000
+Subject: replicate: avoid buffered IO on reads
+
+Perl buffered IO is only reading 8K at a time (or only 4K on older
+versions!) despite us requesting to read in 1MB chunks.  This wastes
+syscalls and can affect TCP window scaling when MogileFS is
+replicating across long fat networks (LFN).
+
+While we're at it, this fixes a long-standing FIXME item to perform
+proper timeouts when reading headers as we're forced to do sysread
+instead of line-buffered I/O.
+
+ref: https://rt.perl.org/Public/Bug/Display.html?id=126403
+(and confirmed by strace-ing replication workers)
+---
+ lib/MogileFS/Worker/Replicate.pm | 78 +++++++++++++++++++++++++++-------------
+ 1 file changed, 53 insertions(+), 25 deletions(-)
+
+diff --git a/lib/MogileFS/Worker/Replicate.pm b/lib/MogileFS/Worker/Replicate.pm
+index f539710..363f20f 100644
+--- a/lib/MogileFS/Worker/Replicate.pm
++++ b/lib/MogileFS/Worker/Replicate.pm
+@@ -9,7 +9,7 @@ use fields (
+ 
+ use List::Util ();
+ use MogileFS::Server;
+-use MogileFS::Util qw(error every debug);
++use MogileFS::Util qw(error every debug wait_for_readability);
+ use MogileFS::Config;
+ use MogileFS::ReplicationRequest qw(rr_upgrade);
+ use Digest;
+@@ -25,6 +25,7 @@ sub new {
+ 
+ # replicator wants
+ sub watchdog_timeout { 90; }
++use constant SOCK_TIMEOUT => 45;
+ 
+ sub work {
+     my $self = shift;
+@@ -530,20 +531,32 @@ sub replicate {
+ #   keep => boolean, whether to keep the connection after reading
+ #   len =>  value of the Content-Length header (integer)
+ # }
++# Returns undef on timeout
+ sub read_headers {
+-    my ($sock) = @_;
+-    my %rv = ();
+-    # FIXME: this can block.  needs to timeout.
+-    my $line = <$sock>;
+-    return unless defined $line;
+-    $line =~ m!\AHTTP/(\d+\.\d+)\s+(\d+)! or return;
+-    $rv{keep} = $1 >= 1.1;
+-    $rv{code} = $2;
++    my ($sock, $intercopy_cb) = @_;
++    my $head = '';
+ 
+-    while (1) {
+-        $line = <$sock>;
+-        return unless defined $line;
+-        last if $line =~ /\A\r?\n\z/;
++    do {
++        wait_for_readability(fileno($sock), SOCK_TIMEOUT) or return;
++        $intercopy_cb->();
++        my $r = sysread($sock, $head, 1024, length($head));
++        if (defined $r) {
++            return if $r == 0; # EOF
++        } elsif ($!{EAGAIN} || $!{EINTR}) {
++            # loop again
++        } else {
++            return;
++        }
++    } until ($head =~ /\r?\n\r?\n/);
++
++    my $data;
++    ($head, $data) = split(/\r?\n\r?\n/, $head, 2);
++    my @head = split(/\r?\n/, $head);
++    $head = shift(@head);
++    $head =~ m!\AHTTP/(\d+\.\d+)\s+(\d+)! or return;
++    my %rv = ( keep => $1 >= 1.1, code => $2 );
++
++    foreach my $line (@head) {
+         if ($line =~ /\AConnection:\s*keep-alive\s*\z/is) {
+             $rv{keep} = 1;
+         } elsif ($line =~ /\AConnection:\s*close\s*\z/is) {
+@@ -552,7 +565,7 @@ sub read_headers {
+             $rv{len} = $1;
+         }
+     }
+-    return \%rv;
++    return (\%rv, $data);
+ }
+ 
+ # copies a file from one Perlbal to another utilizing HTTP
+@@ -652,10 +665,10 @@ sub http_copy {
+     # plugin set a custom host.
+     $get .= "Host: $shttphost\r\n" if $shttphost;
+ 
+-    my $data = '';
+     my ($sock, $dsock);
+     my ($wcount, $bytes_to_read, $written, $remain);
+     my ($stries, $dtries) = (0, 0);
++    my ($sres, $data, $bytes);
+ 
+ retry:
+     $sconn->close("retrying") if $sconn;
+@@ -671,7 +684,7 @@ retry:
+     }
+ 
+     # we just want a content length
+-    my $sres = read_headers($sock);
++    ($sres, $data) = read_headers($sock, $intercopy_cb);
+     unless ($sres) {
+         goto retry if $sconn->retryable && $stries == 1;
+         return $error_unreachable->("Error: Resource $surl failed to return an HTTP response");
+@@ -696,18 +709,26 @@ retry:
+     }
+ 
+     # now read data and print while we're reading.
++    $bytes = length($data);
+     ($written, $remain) = (0, $clen);
+     $bytes_to_read = 1024*1024;  # read 1MB at a time until there's less than that remaining
+     $bytes_to_read = $remain if $remain < $bytes_to_read;
+     $wcount = 0;
+ 
+     while ($bytes_to_read) {
+-        my $bytes = $sock->read($data, $bytes_to_read);
+         unless (defined $bytes) {
+-            return $src_error->("error reading midway through source: $!");
+-        }
+-        if ($bytes == 0) {
+-            return $src_error->("EOF reading midway through source: $!");
++read_again:
++            $bytes = sysread($sock, $data, $bytes_to_read);
++            unless (defined $bytes) {
++                if ($!{EAGAIN} || $!{EINTR}) {
++                    wait_for_readability(fileno($sock), SOCK_TIMEOUT) and
++                        goto read_again;
++                }
++                return $src_error->("error reading midway through source: $!");
++            }
++            if ($bytes == 0) {
++                return $src_error->("EOF reading midway through source: $!");
++            }
+         }
+ 
+         # now we've read in $bytes bytes
+@@ -716,6 +737,7 @@ retry:
+         $digest->add($data) if $digest;
+ 
+         my $data_len = $bytes;
++        $bytes = undef;
+         my $data_off = 0;
+         while (1) {
+             my $wbytes = syswrite($dsock, $data, $data_len, $data_off);
+@@ -757,7 +779,7 @@ retry:
+     }
+ 
+     # now read in the response line (should be first line)
+-    my $dres = read_headers($dsock);
++    my ($dres, $ddata) = read_headers($dsock, $intercopy_cb);
+     unless ($dres) {
+         goto retry if (!$wcount && $dconn->retryable && $dtries == 1);
+         return $dest_error->("Error: HTTP response line not recognized writing to $durl");
+@@ -765,10 +787,11 @@ retry:
+ 
+     # drain the response body if there is one
+     # there may be no dres->{len}/Content-Length if there is no body
+-    if ($dres->{len}) {
+-        my $r = $dsock->read($data, $dres->{len}); # dres->{len} should be tiny
++    my $dlen = ($dres->{len} || 0) - length($ddata);
++    if ($dlen > 0) {
++        my $r = $dsock->read($data, $dlen); # dres->{len} should be tiny
+         if (defined $r) {
+-            if ($r != $dres->{len}) {
++            if ($r != $dlen) {
+                 Mgd::error("Failed to read $r of Content-Length:$dres->{len} bytes for PUT response on $durl");
+                 $dres->{keep} = 0;
+             }
+@@ -776,6 +799,11 @@ retry:
+             Mgd::error("Failed to read Content-Length:$dres->{len} bytes for PUT response on $durl ($!)");
+             $dres->{keep} = 0;
+         }
++    } elsif ($dlen < 0) {
++        Mgd::error("strange response Content-Length:$dres->{len} with ".
++                    length($ddata) .
++                    " extra bytes for PUT response on $durl ($!)");
++        $dres->{keep} = 0;
+     }
+ 
+     # return the connection back to the connection pool
+-- 
+cgit v0.12-2-g5733
+
+


### PR DESCRIPTION
@hfm @pbmasaki 

replicate ワーカーの read(2) を効率するよくパッチが出ているので取り込む PR となります。mogilefs の tar.gz がどのようにしてリリースされるか先が読めないので、パッチで取り込んでいきましょう
## どんなパッチか

replicate ワーカーの read(2) がよい感じになる
### 検証方法
- 1MB のファイルを PUT して、replicate ワーカーを strace する 
- パッチを当てたものと当ててないものとで read(2) の呼び出し方を比較する
#### パッチ無し

read(2) のサイズが一律で 4096 バイトになっています

```
write(5, "PUT /dev6/0/276/415/0276415119.fid HTTP/1.0\r\nConnection: keep-alive\r\nContent-len"..., 96) = 96
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
read(9, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 4096) = 4096
```
#### パッチ有り

なるべく大きなサイズで read(2) するようになっています

```
write(7, "PUT /dev5/0/276/415/0276415122.fid HTTP/1.0\r\nConnection: keep-alive\r\nContent-len"..., 96) = 96
write(7, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 811) = 811
gettimeofday({1454056676, 456286}, NULL) = 0
brk(0x1e4b000)                          = 0x1e4b000
read(5, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 1047765) = 49656
write(7, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 49656) = 49656
gettimeofday({1454056676, 460877}, NULL) = 0
read(5, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 998109) = 40544
write(7, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 40544) = 40544
gettimeofday({1454056676, 461491}, NULL) = 0
read(5, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 957565) = 36200
write(7, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 36200) = 36200
gettimeofday({1454056676, 463818}, NULL) = 0
read(5, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 921365) = 53576
write(7, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"..., 53576) = 53576
```
